### PR TITLE
:sparkles: feat(cargo): implementa auditoria assíncrona com @Async #17

### DIFF
--- a/src/main/java/br/com/floricultura/erp/async/CargoAuditLogger.java
+++ b/src/main/java/br/com/floricultura/erp/async/CargoAuditLogger.java
@@ -1,0 +1,26 @@
+package br.com.floricultura.erp.async;
+
+import br.com.floricultura.erp.model.Cargo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class CargoAuditLogger {
+
+    @Async
+    public void logCargoCreation(Cargo cargo) {
+        try {
+            Thread.sleep(2000);
+
+            log.info("AUDITORIA ASSÍNCRONA: Novo cargo criado - ID: {}, Nome: {}",
+                    cargo.getId(), cargo.getNomeCargo());
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Erro durante o log de auditoria assíncrono para o cargo {}: {}",
+                    cargo.getNomeCargo(), e.getMessage());
+        }
+    }
+}

--- a/src/main/java/br/com/floricultura/erp/services/CargoService.java
+++ b/src/main/java/br/com/floricultura/erp/services/CargoService.java
@@ -2,17 +2,18 @@ package br.com.floricultura.erp.services;
 
 import br.com.floricultura.erp.model.Cargo;
 import br.com.floricultura.erp.repository.CargoRepository;
+import br.com.floricultura.erp.async.CargoAuditLogger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class CargoService {
 
     private final CargoRepository repository;
+    private final CargoAuditLogger auditLogger;
 
     public List<Cargo> listarTodos() {
         return repository.findAll();
@@ -24,7 +25,9 @@ public class CargoService {
     }
 
     public Cargo salvar(Cargo cargo) {
-        return repository.save(cargo);
+        Cargo savedCargo = repository.save(cargo);
+        auditLogger.logCargoCreation(savedCargo);
+        return savedCargo;
     }
 
     public void excluir(Long id) {


### PR DESCRIPTION
Implementação de auditoria assíncrona para o módulo de Cargo.

- Criação do componente CargoAuditLogger responsável por processamento em background
- Integração da auditoria no fluxo de salvamento do CargoService
- Execução assíncrona desacoplada da requisição principal
